### PR TITLE
Uses safe URLs for redirect location field

### DIFF
--- a/lib/adsf/rack/index_file_finder.rb
+++ b/lib/adsf/rack/index_file_finder.rb
@@ -15,7 +15,7 @@ module Adsf::Rack
 
       # Redirect if necessary
       if ::File.directory?(path) && path_info !~ /\/$/
-        new_path_info = path_info + '/'
+        new_path_info = env['PATH_INFO'] + '/'
         return [
           302,
           { 'Location' => new_path_info, 'Content-Type' => 'text/html' },

--- a/test/rack/test_index_file_finder.rb
+++ b/test/rack/test_index_file_finder.rb
@@ -86,4 +86,14 @@ class Adsf::Test::Rack::IndexFileFinder < MiniTest::Unit::TestCase
     assert_equal 'Leon, Roy, Pris, Zhora, etc.', last_response.body
   end
 
+  def test_get_dir_without_slash_with_escaped_url
+    # Create test directory
+    FileUtils.mkdir('animal replicants')
+
+    # Request test directory
+    get '/animal%20replicants'
+    assert last_response.redirect?
+    assert_equal '/animal%20replicants/', last_response.location
+  end
+
 end


### PR DESCRIPTION
This fixes redirect when path has white spaces. While some web servers can work around it, WEBrick was throwing an invalid uri error.