### PR TITLE
change also to minitest gem in test helper file

### DIFF
--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,6 +1,6 @@
 # Load unit testing stuff
 begin
-  require 'minitest/unit'
+  require 'minitest/autorun'
   require 'rack/test'
   require 'mocha/setup'
 rescue => e


### PR DESCRIPTION
Hi,

A previous pull request changed to the minitest gem in the Rakefile. There is a leftover in the test helper file, if one wants to call the tests directly without rake. This change reflects the move to minitest gem also in the helper file used for the tests.

Cheers

Cédric