### PR TITLE
Add Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,21 +28,49 @@ See `adsf --help` for details.
 Using adsf programmatically
 ---------------------------
 
-You can use adsf programmatically in your Rack applications. [Nanoc](https://nanoc.ws/) uses adsf for its “view” command, for example. adsf consists of one middleware class that finds index filenames, and rewrites these requests so that Rack::File can be used to serve these files.
+### IndexFileFinder
 
-Here’s an example middleware/application stack that runs a web server with the "public/" directory as its web root:
+The `Adsf::Rack::IndexFileFinder` middleware makes Rack load an index file (e.g. `index.html`) when requesting a directory. For example, the following runs a web server with the 'public' directory as its web root:
 
-	use Adsf::Rack::IndexFileFinder, :root => "public/"
-	run Rack::File.new("public/")
+```ruby
+use Adsf::Rack::IndexFileFinder, root: 'public'
+run Rack::File.new('public')
+```
 
-The `:root` option is required; it should contain the path to the web root.
+It takes the following options:
 
-You can also specify an `:index_filenames` option, containing the names of the index filenames that will be served when a directory containing an index file is requested. Usually, this will simply be `[ 'index.html' ]`, but under different circumstances (when using IIS, for example), the array may have to be modified to include index filenames such as `default.html` or `index.xml`. Here’s an example middleware/application stack that uses custom index filenames:
+* `root` (required): the path to the web root
 
+* `index_filenames` (optional; defaults to `['index.html']`): contains the names of the index filenames that will be served when a directory containing an index file is requested. Usually, this will simply be `['index.html']`, but under different circumstances (when using IIS, for example), the array may have to be modified to include index filenames such as `default.html` or `index.xml`. Here’s an example middleware/application stack that uses custom index filenames:
+
+	```ruby
 	use Adsf::Rack::IndexFileFinder,
-	  :root => "public/",
-	  :index_filenames => %w( index.html index.xhtml index.xml )
-	run Rack::File.new("public/")
+		root: 'public',
+		index_filenames: %w[index.html index.xhtml]
+	run Rack::File.new('public')
+	```
+
+### Server
+
+`Adsf::Server` runs a web server programmatically. For example:
+
+```ruby
+server = Adsf::Server.new(root: 'public')
+
+%w[INT TERM].each do |s|
+  Signal.trap(s) { server.stop }
+end
+
+server.run
+```
+
+It takes the following options:
+
+* `root` (required): the path to the web root
+* `index_filenames` (optional; defaults to `['index.html']`): (see above)
+* `host` (optional; defaults to `'127.0.0.1'`): the address of the network interface to listen on
+* `port` (optional; defaults to `3000`): the port ot listen on
+* `handler` (optional): the Rack handler to use
 
 Contributors
 ------------

--- a/bin/adsf
+++ b/bin/adsf
@@ -6,7 +6,6 @@ require 'rack'
 require 'optparse'
 require 'adsf'
 
-# Parse options
 options = {
   handler: nil,
   port: 3000,
@@ -14,6 +13,7 @@ options = {
   root: '.',
   host: '0.0.0.0'
 }
+
 OptionParser.new do |opts|
   opts.banner = 'Usage: adsf [options]'
 
@@ -57,25 +57,10 @@ OptionParser.new do |opts|
   end
 end.parse!
 
-# Find handler
-handler = Rack::Handler.get(options[:handler])
-handler = Rack::Handler::WEBrick if handler.nil?
+server = Adsf::Server.new(options)
 
-# Create app
-app = Rack::Builder.new do
-  use Rack::CommonLogger
-  use Rack::ShowExceptions
-  use Rack::Lint
-  use Adsf::Rack::IndexFileFinder,
-      root: options[:root],
-      index_filenames: options[:index_filenames]
-  run Rack::File.new(options[:root])
-end.to_app
-
-# Be quittable
 %w[INT TERM].each do |s|
-  Signal.trap(s) { handler.shutdown }
+  Signal.trap(s) { server.stop }
 end
 
-# Run
-handler.run(app, Port: options[:port], Host: options[:host])
+server.run

--- a/lib/adsf.rb
+++ b/lib/adsf.rb
@@ -1,5 +1,9 @@
+require 'rack'
+require 'thread'
+
 module Adsf
 end
 
 require 'adsf/version'
 require 'adsf/rack'
+require 'adsf/server'

--- a/lib/adsf/server.rb
+++ b/lib/adsf/server.rb
@@ -1,0 +1,68 @@
+module Adsf
+  class Server
+    DEFAULT_HANDLER_NAME = :thin
+
+    def initialize(root:, index_filenames: ['index.html'], host: '127.0.0.1', port: 3000, handler: nil)
+      @root = root
+      @index_filenames = index_filenames
+      @host = host
+      @port = port
+      @handler = handler
+
+      @q = SizedQueue.new(1)
+    end
+
+    def run
+      handler = build_handler
+      app = build_app(root: @root, index_filenames: @index_filenames)
+
+      url = "http://#{@host}:#{@port}/"
+      puts "View the site at #{url}"
+
+      handler.run(app, Host: @host, Port: @port) do |server|
+        wait_for_stop_async(server)
+      end
+    end
+
+    def stop
+      @q << true
+    end
+
+    private
+
+    def wait_for_stop_async(server)
+      Thread.new { wait_for_stop(server) }
+    end
+
+    def wait_for_stop(server)
+      @q.pop
+      server.stop
+    end
+
+    def build_app(root:, index_filenames:)
+      ::Rack::Builder.new do
+        use ::Rack::CommonLogger
+        use ::Rack::ShowExceptions
+        use ::Rack::Lint
+        use ::Rack::Head
+        use Adsf::Rack::IndexFileFinder,
+            root: root,
+            index_filenames: index_filenames
+
+        run ::Rack::File.new(root)
+      end.to_app
+    end
+
+    def build_handler
+      if @handler
+        ::Rack::Handler.get(@handler)
+      else
+        begin
+          ::Rack::Handler.get(DEFAULT_HANDLER_NAME)
+        rescue LoadError
+          ::Rack::Handler::WEBrick
+        end
+      end
+    end
+  end
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -11,6 +11,7 @@ SimpleCov.formatters = SimpleCov::Formatter::MultiFormatter.new(
 
 require 'rack/test'
 require 'minitest/autorun'
+require 'net/http'
 
 require 'adsf'
 

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -1,0 +1,86 @@
+require 'helper'
+
+class Adsf::Test::Server < MiniTest::Test
+  include Rack::Test::Methods
+  include Adsf::Test::Helpers
+
+  def run_server(opts = {})
+    opts = { root: 'output', port: 50_386 }.merge(opts)
+    server = Adsf::Server.new(opts)
+    thread = Thread.new do
+      Thread.current.abort_on_exception = true
+      server.run
+    end
+
+    # Wait for server to start up
+    20.times do |i|
+      begin
+        Net::HTTP.get('127.0.0.1', '/', 50_386)
+      rescue Errno::ECONNREFUSED, Errno::ECONNRESET
+        sleep(0.1 * 1.2**i)
+        retry
+      end
+      break
+    end
+
+    yield
+  ensure
+    server.stop
+    thread.join
+  end
+
+  def setup
+    super
+    FileUtils.mkdir_p('output')
+  end
+
+  def test_default_config__serve_index_html
+    File.write('output/index.html', 'Hello there! Nanoc loves you! <3')
+    run_server do
+      assert_equal 'Hello there! Nanoc loves you! <3', Net::HTTP.get('127.0.0.1', '/', 50_386)
+    end
+  end
+
+  def test_explicit_handler__serve_index_html
+    File.write('output/index.html', 'Hello there! Nanoc loves you! <3')
+    run_server(handler: :webrick) do
+      assert_equal 'Hello there! Nanoc loves you! <3', Net::HTTP.get('127.0.0.1', '/', 50_386)
+    end
+  end
+
+  def test_default_config__no_serve_index_xhtml
+    File.write('output/index.xhtml', 'Hello there! Nanoc loves you! <3')
+    run_server do
+      assert_equal "File not found: /\n", Net::HTTP.get('127.0.0.1', '/', 50_386)
+    end
+  end
+
+  def test_default_config__no_serve_wrong_index
+    File.write('output/index666.html', 'Hello there! Nanoc loves you! <3')
+    run_server do
+      assert_equal "File not found: /\n", Net::HTTP.get('127.0.0.1', '/', 50_386)
+    end
+  end
+
+  def test_index_xhtml_in_index_filenames__serve_index_xhtml
+    File.write('output/index.xhtml', 'Hello there! Nanoc loves you! <3')
+    run_server(index_filenames: ['index.xhtml']) do
+      assert_equal 'Hello there! Nanoc loves you! <3', Net::HTTP.get('127.0.0.1', '/', 50_386)
+    end
+  end
+
+  def test_non_local_interfaces
+    addresses = Socket.getifaddrs.map(&:addr).select(&:ipv4?).map(&:ip_address)
+    non_local_addresses = addresses - ['127.0.0.1']
+
+    if non_local_addresses.empty?
+      skip 'Need non-local network interfaces for this spec'
+    end
+
+    run_server do
+      assert_raises(Errno::ECONNREFUSED) do
+        Net::HTTP.get(non_local_addresses[0], '/', 50_386)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This adds `Adsf::Server`, which is essentially what `nanoc view` is already doing.

Future goals is to have this be able to deal with live-reloading as well (e.g. `adsf --live-reload`) — but that is for a future PR.