### PR TITLE
Add CORS headers

### DIFF
--- a/lib/adsf/rack.rb
+++ b/lib/adsf/rack.rb
@@ -4,3 +4,4 @@ module Adsf
 end
 
 require 'adsf/rack/index_file_finder'
+require 'adsf/rack/cors'

--- a/lib/adsf/rack/cors.rb
+++ b/lib/adsf/rack/cors.rb
@@ -1,0 +1,19 @@
+module Adsf::Rack
+  class CORS
+    def initialize(app)
+      @app = app
+    end
+
+    def call(env)
+      status, headers, body = *@app.call(env)
+
+      new_headers =
+        headers.merge(
+          'Access-Control-Allow-Origin' => '*',
+          'Access-Control-Allow-Headers' => 'Origin, X-Requested-With, Content-Type, Accept, Range',
+        )
+
+      [status, new_headers, body]
+    end
+  end
+end

--- a/lib/adsf/server.rb
+++ b/lib/adsf/server.rb
@@ -45,6 +45,7 @@ module Adsf
         use ::Rack::ShowExceptions
         use ::Rack::Lint
         use ::Rack::Head
+        use Adsf::Rack::CORS
         use Adsf::Rack::IndexFileFinder,
             root: root,
             index_filenames: index_filenames

--- a/test/test_server.rb
+++ b/test/test_server.rb
@@ -69,6 +69,20 @@ class Adsf::Test::Server < MiniTest::Test
     end
   end
 
+  def test_access_control_allow_origin
+    run_server do
+      response = Net::HTTP.get_response('127.0.0.1', '/', 50_386)
+      assert_equal '*', response['Access-Control-Allow-Origin']
+    end
+  end
+
+  def test_access_control_allow_headers
+    run_server do
+      response = Net::HTTP.get_response('127.0.0.1', '/', 50_386)
+      assert_equal 'Origin, X-Requested-With, Content-Type, Accept, Range', response['Access-Control-Allow-Headers']
+    end
+  end
+
   def test_non_local_interfaces
     addresses = Socket.getifaddrs.map(&:addr).select(&:ipv4?).map(&:ip_address)
     non_local_addresses = addresses - ['127.0.0.1']


### PR DESCRIPTION
Fixes #9 by always adding CORS headers.

I don’t believe this creates a security concern, because `adsf` is intended as a development, local-only web server.