### PR TITLE
Aligning stale-when-error Cache-Control extension with RFC5861

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ Style/TrailingCommaInArrayLiteral:
 Style/TrailingCommaInHashLiteral:
   EnforcedStyleForMultiline: comma
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 Style/ClassAndModuleChildren:

--- a/adsf/lib/adsf/rack/caching.rb
+++ b/adsf/lib/adsf/rack/caching.rb
@@ -11,7 +11,7 @@ module Adsf::Rack
 
       new_headers =
         headers.merge(
-          'Cache-Control' => 'max-age=0, stale-while-error=0',
+          'Cache-Control' => 'max-age=0, stale-if-error=0',
         )
 
       [status, new_headers, body]

--- a/adsf/test/test_server.rb
+++ b/adsf/test/test_server.rb
@@ -92,7 +92,7 @@ class Adsf::Test::Server < MiniTest::Test
   def test_access_caching_headers
     run_server do
       response = Net::HTTP.get_response('127.0.0.1', '/', 50_386)
-      assert_equal 'max-age=0, stale-while-error=0', response['Cache-Control']
+      assert_equal 'max-age=0, stale-if-error=0', response['Cache-Control']
     end
   end
 


### PR DESCRIPTION
According to [the spec](https://tools.ietf.org/html/rfc5861#section-4), shouldn't it be `stale-if-error`?